### PR TITLE
fix/CreateTicket

### DIFF
--- a/src/TechChallenge.Application/Contracts/Tickets/CreateTicketRequest.cs
+++ b/src/TechChallenge.Application/Contracts/Tickets/CreateTicketRequest.cs
@@ -1,0 +1,18 @@
+namespace TechChallenge.Application.Contracts.Tickets
+{
+    /// <summary>
+    /// Represents the request ticket creation.
+    /// </summary>
+    public sealed class CreateTicketRequest
+    {
+        /// <summary>
+        /// Gets or sets the category.
+        /// </summary>
+        public int IdCategory { get; set; }
+
+        /// <summary>
+        /// Gets or sets the description.
+        /// </summary>
+        public string Description { get; set; }
+    }
+}

--- a/src/TechChallenge.Application/Contracts/Tickets/UpdateTicketRequest.cs
+++ b/src/TechChallenge.Application/Contracts/Tickets/UpdateTicketRequest.cs
@@ -1,9 +1,9 @@
 namespace TechChallenge.Application.Contracts.Tickets
 {
     /// <summary>
-    /// Represents the request ticket.
+    /// Represents the update ticket request.
     /// </summary>
-    public sealed class TicketRequest
+    public sealed class UpdateTicketRequest
     {
         /// <summary>
         /// Gets or sets the category.

--- a/src/TechChallenge.Application/Core/Abstractions/Services/ITicketService.cs
+++ b/src/TechChallenge.Application/Core/Abstractions/Services/ITicketService.cs
@@ -11,7 +11,7 @@ namespace TechChallenge.Application.Core.Abstractions.Services
 
         Task<DetailedTicketResponse> GetTicketByIdAsync(int idTicket, int idUser);
         Task<PagedList<TicketResponse>> GetTicketsAsync(GetTicketsRequest request, int idUser);
-        Task CreateAsync(int idCategory, int idUserRequester, string description);
+        Task<int> CreateAsync(int idCategory, string description, int idUserRequester);
         Task UpdateAsync(int idTicket, int idCategory, string description, int idUserPerformedAction);
         Task ChangeStatusAsync(int idTicket, TicketStatuses changedStatus, int idUserPerformedAction);
         Task CancelAsync(int idTicket, string cancellationReason);

--- a/src/TechChallenge.Domain/Entities/Ticket.cs
+++ b/src/TechChallenge.Domain/Entities/Ticket.cs
@@ -2,7 +2,6 @@ using System;
 using TechChallenge.Domain.Errors;
 using TechChallenge.Domain.Exceptions;
 using TechChallenge.Domain.Enumerations;
-using TechChallenge.Domain.Core.Utility;
 using TechChallenge.Domain.Core.Primitives;
 using TechChallenge.Domain.Core.Abstractions;
 using TechChallenge.Domain.Extensions;
@@ -35,15 +34,20 @@ namespace TechChallenge.Domain.Entities
         private Ticket()
         { }
 
-        public Ticket(int idCategory, int idUserRequester, string description)
+        public Ticket(Category category, string description, User userRequester)
         {
-            Ensure.GreaterThan(idCategory, 0, "The category identifier must be greater than zero.", nameof(idCategory));
-            Ensure.GreaterThan(idUserRequester, 0, "The user requester identifier must be greater than zero.", nameof(idUserRequester));
-            Ensure.NotEmpty(description, "The ticket description is required.", nameof(description));
+            if (category is null)
+                throw new DomainException(DomainErrors.Category.NotFound);
 
-            IdCategory = idCategory;
-            IdUserRequester = idUserRequester;
+            if (userRequester is null)
+                throw new DomainException(DomainErrors.User.NotFound);
+
+            if (description.IsNullOrWhiteSpace())
+                throw new DomainException(DomainErrors.Ticket.DescriptionIsRequired);
+
+            IdCategory = category.Id;
             Description = description;
+            IdUserRequester = userRequester.Id;
             IdStatus = (byte)TicketStatuses.New;
         }
 
@@ -56,7 +60,7 @@ namespace TechChallenge.Domain.Entities
             if (category is null)
                 throw new DomainException(DomainErrors.Category.NotFound);
 
-            if (description.IsNullOrEmpty())
+            if (description.IsNullOrWhiteSpace())
                 throw new DomainException(DomainErrors.Ticket.DescriptionIsRequired);
 
             if (userPerformedAction is null)
@@ -97,7 +101,7 @@ namespace TechChallenge.Domain.Entities
             if (userPerformedAction.IdRole == (byte)UserRoles.General)
                 throw new InvalidPermissionException(DomainErrors.Ticket.CannotBeCompletedByThisUser);
 
-            if (cancellationReason.IsNullOrEmpty())
+            if (cancellationReason.IsNullOrWhiteSpace())
                 throw new DomainException(DomainErrors.Ticket.CancellationReasonIsRequired);
 
             CancellationReason = cancellationReason;

--- a/src/TechChallenge.Domain/Errors/DomainErrors.cs
+++ b/src/TechChallenge.Domain/Errors/DomainErrors.cs
@@ -125,9 +125,9 @@ namespace TechChallenge.Domain.Errors
                 "Ticket.CancellationReasonIsRequired",
                 "The reason for ticket cancellation is required.");
 
-            public static Error InvalidOrMissingUpdateData => new Error(
-                "Ticket.InvalidOrMissingUpdateData",
-                "The update data is invalid or missing.");
+            public static Error DataSentIsInvalid => new Error(
+                "Ticket.DataSentIsInvalid",
+                "The ticket data sent in the request is invalid.");
 
             public static Error DescriptionIsRequired = new Error(
                 "Ticket.DescriptionIsRequired",


### PR DESCRIPTION
PR Com as correções abaixo para o Endpoint Tickets.Create.:

- [x] Quando coloco uma categoria que não existe, o código quebra (Null pointer - Object reference not set to an instance of an object.). Favor incluir validação para verificar se a categoria informada realmente existe. 
- [x] Após a criação, o endpoint deve retornar o código do ticket (ID) para o usuário. 
- [x] Se eu coloco a categoria 0 - que não existe - o código não dá null pointer, mas retorna o seguinte erro: The server encountered an unrecoverable error.O mesmo erro acontece quando eu coloco uma string vazia na descrição. 

Obrigado pelos review e Feedbacks.

